### PR TITLE
feat: Move sidebar container to the top

### DIFF
--- a/Sticker King  Calculator/sidebar.css
+++ b/Sticker King  Calculator/sidebar.css
@@ -37,8 +37,6 @@ body {
   padding: 0;
   min-height: 100vh;
   display: flex;
-  justify-content: center;
-  align-items: center;
   transition: background 0.4s ease;
 }
 
@@ -51,8 +49,6 @@ body.dark-mode {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: center;
-  align-items: center;
   padding: 15px;
 }
 


### PR DESCRIPTION
The container was previously centered on the page. This change removes the CSS properties that were causing the centering, moving the container to the top of the page.